### PR TITLE
Update the FlashCam ADC waveform decoder to reflect the extra bit now…

### DIFF
--- a/Decoders/ORFlashCamADCDecoder.cc
+++ b/Decoders/ORFlashCamADCDecoder.cc
@@ -39,9 +39,22 @@ UInt_t ORFlashCamADCDecoder::GetEventBaseline(size_t event){
 }
 
 UShort_t ORFlashCamADCDecoder::GetEventChannel(size_t event){
+  return GetEventChannel(event, "ORFlashCamWaveformDecoder");
+}
+
+UShort_t ORFlashCamADCDecoder::GetEventChannel(size_t event,
+					       std::string decoder){
   if(event >= GetNumberOfEvents()) return 0;
-  return UShort_t((CrateOf() << 12) +
-		  (CardOf()  <<  4) + ((fDataRecord[2] & 0x00003c00) >> 10));
+  if(decoder == "ORFlashCamADCWaveformDecoder")
+    return UShort_t((CrateOf() << 12) +
+		    (CardOf()  <<  4) + ((fDataRecord[2] & 0x00003c00) >> 10));
+  else{
+    if(decoder != "ORFlashCamWaveformDecoder")
+      ORLog(kWarning)<<"GetEventChannel(event, decoder): unrecognized decoder "
+		     <<decoder<<" default to ORFlashCamWaveformDecoder"<<endl;
+    return UShort_t((CrateOf() << 12) +
+		    (CardOf()  <<  4) + ((fDataRecord[2] & 0x00003e00) >>  9));
+  }
 }
 
 size_t ORFlashCamADCDecoder::GetEventWaveformLength(size_t event){

--- a/Decoders/ORFlashCamADCDecoder.hh
+++ b/Decoders/ORFlashCamADCDecoder.hh
@@ -26,6 +26,7 @@ public:
   virtual UInt_t GetEventEnergy(size_t event);
   virtual UInt_t GetEventBaseline(size_t event);
   virtual UShort_t GetEventChannel(size_t event);
+  virtual UShort_t GetEventChannel(size_t event, std::string decoder);
 
   /* Waveform level functions */
   virtual size_t GetEventWaveformLength(size_t event);


### PR DESCRIPTION
… used in the channel number from the Orca data format.  Add another method to get the channel number in the old format by specifying the Orca decoder name.